### PR TITLE
Migrate the library to null safety

### DIFF
--- a/lib/src/bit_array.dart
+++ b/lib/src/bit_array.dart
@@ -20,7 +20,7 @@ class BitArray extends BitSet {
   }
 
   /// Creates a bit array using a generic bit set.
-  factory BitArray.fromBitSet(BitSet set, {int length}) {
+  factory BitArray.fromBitSet(BitSet set, {int? length}) {
     length ??= set.length;
     final setDataLength = _bufferLength32(set.length);
     final data = Uint32List(_bufferLength32(length));

--- a/lib/src/composite_counter.dart
+++ b/lib/src/composite_counter.dart
@@ -26,7 +26,7 @@ class CompositeCounter {
   final int _indexMask;
   final int _offsetMask;
 
-  CompositeCounter({this.chunkBits = 16, List<BitCounterChunk> chunks})
+  CompositeCounter({this.chunkBits = 16, List<BitCounterChunk>? chunks})
       : _chunkLength = (1 << chunkBits),
         _indexMask = (1 << chunkBits) - 1,
         _offsetMask = ~((1 << chunkBits) - 1),
@@ -52,7 +52,7 @@ class CompositeCounter {
   /// TODO: add BigInt support.
   void operator []=(int index, int value) {
     final chunkOffset = index & _offsetMask;
-    final c = _getChunk(chunkOffset, true);
+    final c = _getChunk(chunkOffset, true)!;
     c.bitCounter[index & _indexMask] = value;
   }
 
@@ -64,7 +64,7 @@ class CompositeCounter {
       throw StateError('Only sets with the same chunkBits can be added');
     }
     for (BitSetChunk bsc in set.chunks) {
-      final c = _getChunk(bsc.offset, true);
+      final c = _getChunk(bsc.offset, true)!;
       c.bitCounter.addBitSet(bsc.bitSet, shiftLeft: shiftLeft);
     }
   }
@@ -77,7 +77,7 @@ class CompositeCounter {
       throw StateError('Only counters with the same chunkBits can be added');
     }
     for (BitCounterChunk bcc in counter.chunks) {
-      final c = _getChunk(bcc.offset, true);
+      final c = _getChunk(bcc.offset, true)!;
       c.bitCounter.addBitCounter(bcc.bitCounter, shiftLeft: shiftLeft);
     }
   }
@@ -126,7 +126,7 @@ class CompositeCounter {
   /// The increment starts at the bit position specified by [shiftLeft].
   void increment(int index, {int shiftLeft = 0}) {
     final chunkOffset = index & _offsetMask;
-    final c = _getChunk(chunkOffset, true);
+    final c = _getChunk(chunkOffset, true)!;
     c.bitCounter.increment(index & _indexMask, shiftLeft: shiftLeft);
   }
 
@@ -152,12 +152,11 @@ class CompositeCounter {
     return CompositeSet(
         chunkBits: chunkBits,
         chunks: chunks
-            .map((c) {
+            .expand<BitSetChunk>((c) {
               final set = c.bitCounter.toMask(minValue: minValue);
-              if (set.isEmpty) return null;
-              return BitSetChunk(c.offset, set);
+              if (set.isEmpty) return [];
+              return [BitSetChunk(c.offset, set)];
             })
-            .where((c) => c != null)
             .toList());
   }
 
@@ -167,7 +166,7 @@ class CompositeCounter {
       throw Exception('chunkBits must match: $chunkBits != ${other.chunkBits}');
     }
     for (BitCounterChunk oc in other.chunks) {
-      final c = _getChunk(oc.offset, true);
+      final c = _getChunk(oc.offset, true)!;
       if (c.bitCounter.bitLength == 0) {
         c.bitCounter._bits.addAll(oc.bitCounter._bits.map((a) => a.clone()));
       } else {
@@ -238,7 +237,7 @@ class CompositeCounter {
     );
   }
 
-  BitCounterChunk _getChunk(int offset, [bool forInsert = false]) {
+  BitCounterChunk? _getChunk(int offset, [bool forInsert = false]) {
     int left = 0;
     int right = chunks.length - 1;
     while (left <= right) {

--- a/lib/src/composite_set.dart
+++ b/lib/src/composite_set.dart
@@ -41,7 +41,7 @@ class CompositeSet extends BitSet {
   final int _indexMask;
   final int _offsetMask;
 
-  CompositeSet({this.chunkBits = 16, List<BitSetChunk> chunks})
+  CompositeSet({this.chunkBits = 16, List<BitSetChunk>? chunks})
       : _chunkLength = (1 << chunkBits),
         _indexMask = (1 << chunkBits) - 1,
         _offsetMask = ~((1 << chunkBits) - 1),
@@ -61,7 +61,7 @@ class CompositeSet extends BitSet {
   /// Sets the bit specified by the [index] to the [value].
   void operator []=(int index, bool value) {
     final chunkOffset = index & _offsetMask;
-    final c = _getChunk(chunkOffset, true);
+    final c = _getChunk(chunkOffset, true)!;
     c.asBitArray(_chunkLength)[index & _indexMask] = value;
   }
 
@@ -132,13 +132,13 @@ class CompositeSet extends BitSet {
   }
 
   /// Optimize the containers.
-  void optimize({BitArrayOptimizer optimizer, int removeThreshold = 0}) {
+  void optimize({BitArrayOptimizer? optimizer, int removeThreshold = 0}) {
     optimizer ??= chunkBits == 16 ? _optimizeBitArray16 : _simpleOptimizer;
     int removeCount = 0;
     for (BitSetChunk c in chunks) {
       if (c._set is BitArray) {
         final bitSet = optimizer(c._set as BitArray);
-        if (bitSet != null && bitSet is! BitArray) {
+        if (bitSet is! BitArray) {
           c._set = bitSet;
         }
       }
@@ -170,7 +170,7 @@ class CompositeSet extends BitSet {
     }
   }
 
-  BitSetChunk _getChunk(int offset, [bool forInsert = false]) {
+  BitSetChunk? _getChunk(int offset, [bool forInsert = false]) {
     int left = 0;
     int right = chunks.length - 1;
     while (left <= right) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/isoos/bit_array
 author: Istvan Soos <istvan.soos@gmail.com>
 
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 #dependencies:
 #


### PR DESCRIPTION
This makes it easier to use the library in null-safe code.

See https://dart.dev/null-safety for more information.