### PR TITLE
[Bug Fix] Edge case: BitSet when highest bit index is a multiplication of 32

### DIFF
--- a/lib/src/bit_counter.dart
+++ b/lib/src/bit_counter.dart
@@ -71,9 +71,8 @@ class BitCounter {
   ///
   /// The add starts at the bit position specified by [shiftLeft].
   void addBitSet(BitSet set, {int shiftLeft = 0}) {
-    // From last bit index to bit array length: +1
-    if (_length < set.length + 1) {
-      _length = set.length + 1;
+    if (_length < set.length) {
+      _length = set.length;
       _bits.forEach((a) => a.length = _length);
     }
     for (int i = _bits.length; i < shiftLeft; i++) {

--- a/lib/src/bit_counter.dart
+++ b/lib/src/bit_counter.dart
@@ -71,8 +71,9 @@ class BitCounter {
   ///
   /// The add starts at the bit position specified by [shiftLeft].
   void addBitSet(BitSet set, {int shiftLeft = 0}) {
-    if (_length < set.length) {
-      _length = set.length;
+    // From last bit index to bit array length: +1
+    if (_length < set.length + 1) {
+      _length = set.length + 1;
       _bits.forEach((a) => a.length = _length);
     }
     for (int i = _bits.length; i < shiftLeft; i++) {

--- a/lib/src/bit_set.dart
+++ b/lib/src/bit_set.dart
@@ -108,7 +108,7 @@ class ListSet extends BitSet {
   }
 
   @override
-  int get length => _list.isEmpty ? 0 : _list.last;
+  int get length => _list.isEmpty ? 0 : _list.last + 1;
 
   @override
   int get cardinality {

--- a/test/bit_counter_test.dart
+++ b/test/bit_counter_test.dart
@@ -99,6 +99,12 @@ void main() {
       expect(counter[2001], 0);
     });
 
+    test('bit sets (edge case)', () {
+      final counter = BitCounter(0);
+      counter.addBitSet(ListSet.fromSorted([0, 2, 5, 2048]));
+      expect(counter[2048], 1);
+    });
+
     test('bit set with shift', () {
       final counter = BitCounter(128);
       counter.addBitSet(ListSet.fromSorted([0, 2, 5]), shiftLeft: 3);

--- a/test/bit_set_test.dart
+++ b/test/bit_set_test.dart
@@ -7,7 +7,7 @@ void main() {
     final set = ListSet.fromSorted([23, 45, 78, 98, 101, 102, 103]);
 
     test('simple values', () {
-      expect(set.length, 103);
+      expect(set.length, 104);
       expect(set.cardinality, 7);
       expect(set[22], isFalse);
       expect(set[23], isTrue);


### PR DESCRIPTION
Hi,

The following test will fail on existing code:
```
    test('bit sets (edge case)', () {
      final counter = BitCounter(0);
      counter.addBitSet(ListSet.fromSorted([0, 2, 5, 2048]));
      expect(counter[2048], 1);
    });
```

The reason for that is that 2048 / 32 is an integer number, so the `hasExtra` value in `_bufferLength32` will be 0.
In this edge case (whenever the highest bit index for bit set is a multiplication of 32), the bit array size will not be sufficient (one bit missing).
The corret fix is to use last bit index +1 for the length of the bit array (see commit).

